### PR TITLE
Added workflows + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     # Run it at a specific time so that we don't get emails all day long
-    time: "0:00"
+    time: "00:00"
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: "*"
@@ -18,5 +18,5 @@ updates:
   schedule:
     interval: daily
     # Run it at a specific time so that we don't get emails all day long
-    time: "0:00"
+    time: "00:00"
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    # Run it at a specific time so that we don't get emails all day long
+    time: "0:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: "*"
+    # GitHub actions are using git tags (v1 = v1.2 = v1.2.3) which should be compatible until a major change is performed
+    update-types: 
+    - "version-update:semver-minor"
+    - "version-update:semver-patch"
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    # Run it at a specific time so that we don't get emails all day long
+    time: "0:00"
+  open-pull-requests-limit: 10

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -1,0 +1,55 @@
+name: Check Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ develop ]
+    paths-ignore: 
+      - '**.md'
+  pull_request:
+    branches: [ develop ]
+    paths-ignore: 
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '8'
+        java-package: jdk+fx
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+      
+    - name: Build with Maven
+      run: mvn -B clean verify
+      
+    - name: Check for uncommited changes
+      run: |
+        if [[ "$(git status --porcelain)" != "" ]]; then
+          echo ----------------------------------------
+          echo git status
+          echo ----------------------------------------
+          git status
+          echo ----------------------------------------
+          echo git diff
+          echo ----------------------------------------
+          git diff
+          echo ----------------------------------------
+          echo Troubleshooting
+          echo ----------------------------------------
+          echo "::error::Unstaged changes detected. Locally try running: git clean -ffdx && mvn -B clean verify"
+          exit 1
+        fi

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -20,8 +20,8 @@ jobs:
         java: [11, 17-ea]
         java-package: [jdk]
         distribution: [adopt]
-        # When building Java 8 we need JavaFX on JDK basis
         include: 
+          # When building Java 8 we need JavaFX on JDK basis
           - java: 8
             java-package: jdk+fx
             distribution: zulu
@@ -43,9 +43,16 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+          
+    # Required to map 17-ea to 17
+    # cut away early access and other stuff
+    - name: Determine build profile java 
+      id: determine_bp_java
+      run: |
+        echo "::set-output name=version::$(echo ${{ matrix.java }} | | sed 's/[^0-9]*//g')"
       
     - name: Build with Maven
-      run: mvn -B clean verify -P java${{ matrix.java }}
+      run: mvn -B clean verify -P java${{ steps.determine_bp_java.outputs.version }}
       
     - name: Check for uncommited changes
       run: |

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -12,54 +12,12 @@ on:
       - '**.md'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v2
-      
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'zulu'
-        java-version: '8'
-        java-package: jdk+fx
-
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-      
-    - name: Build with Maven
-      run: mvn -B clean verify
-      
-    - name: Check for uncommited changes
-      run: |
-        if [[ "$(git status --porcelain)" != "" ]]; then
-          echo ----------------------------------------
-          echo git status
-          echo ----------------------------------------
-          git status
-          echo ----------------------------------------
-          echo git diff
-          echo ----------------------------------------
-          git diff
-          echo ----------------------------------------
-          echo Troubleshooting
-          echo ----------------------------------------
-          echo "::error::Unstaged changes detected. Locally try running: git clean -ffdx && mvn -B clean verify"
-          exit 1
-        fi
-
   build_lts:
     runs-on: ubuntu-latest
     
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11] #, 17]
 
     steps:
     - uses: actions/checkout@v2
@@ -85,6 +43,25 @@ jobs:
     - name: Debug
       run: ls -lha target
       
+    - name: Check for uncommited changes
+      run: |
+        if [[ "$(git status --porcelain)" != "" ]]; then
+          echo ----------------------------------------
+          echo git status
+          echo ----------------------------------------
+          git status
+          echo ----------------------------------------
+          echo git diff
+          echo ----------------------------------------
+          git diff
+          echo ----------------------------------------
+          echo Troubleshooting
+          echo ----------------------------------------
+          echo "::error::Unstaged changes detected. Locally try running: git clean -ffdx && mvn -B clean verify"
+          exit 1
+        fi
+
+      
   build_xdev_ide:
     runs-on: ubuntu-latest
     
@@ -107,7 +84,7 @@ jobs:
           ${{ runner.os }}-maven-
       
     - name: Build with Maven
-      run: mvn -B clean verify -Pxdev-ide
+      run: mvn -B clean verify -Pjava8,xdev-ide
       
     - name: Debug
       run: ls -lha target

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -40,9 +40,6 @@ jobs:
     - name: Build with Maven
       run: mvn -B clean verify -P java${{ matrix.java }}
       
-    - name: Debug
-      run: ls -lha target
-      
     - name: Check for uncommited changes
       run: |
         if [[ "$(git status --porcelain)" != "" ]]; then

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    
     steps:
     - uses: actions/checkout@v2
       
@@ -53,3 +53,61 @@ jobs:
           echo "::error::Unstaged changes detected. Locally try running: git clean -ffdx && mvn -B clean verify"
           exit 1
         fi
+
+  build_lts:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        java: [8, 11, 17]
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: ${{ matrix.java }}
+        java-package: jdk+fx
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+      
+    - name: Build with Maven
+      run: mvn -B clean verify -P ${{ matrix.java }}
+      
+    - name: Debug
+      run: ls -lha target
+      
+  build_xdev_ide:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '8'
+        java-package: jdk+fx
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+      
+    - name: Build with Maven
+      run: mvn -B clean verify -Pxdev-ide
+      
+    - name: Debug
+      run: ls -lha target

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -17,7 +17,7 @@ jobs:
     
     strategy:
       matrix:
-        java: [11, 17-ea]
+        java: [11] #, 17-ea]
         java-package: [jdk]
         distribution: [adopt]
         include: 
@@ -43,16 +43,9 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-          
-    # Required to map 17-ea to 17
-    # cut away early access and other stuff
-    - name: Determine build profile java 
-      id: determine_bp_java
-      run: |
-        echo "::set-output name=version::$(echo ${{ matrix.java }} | sed 's/[^0-9]*//g')"
       
     - name: Build with Maven
-      run: mvn -B clean verify -P java${{ steps.determine_bp_java.outputs.version }}
+      run: mvn -B clean verify -P java${{ matrix.java }}
       
     - name: Check for uncommited changes
       run: |

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       
-    - name: Set up JDK 8
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
@@ -38,7 +38,7 @@ jobs:
           ${{ runner.os }}-maven-
       
     - name: Build with Maven
-      run: mvn -B clean verify -P ${{ matrix.java }}
+      run: mvn -B clean verify -P java${{ matrix.java }}
       
     - name: Debug
       run: ls -lha target
@@ -68,7 +68,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       
-    - name: Set up JDK 8
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -60,7 +60,11 @@ jobs:
           echo "::error::Unstaged changes detected. Locally try running: git clean -ffdx && mvn -B clean verify"
           exit 1
         fi
-
+        
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jars-lts-${{ matrix.java }}
+        path: target/*.jar
       
   build_xdev_ide:
     runs-on: ubuntu-latest
@@ -86,5 +90,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B clean verify -Pjava8,xdev-ide
       
-    - name: Debug
-      run: ls -lha target
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jars-xdev-ide
+        path: target/*.jar

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -17,7 +17,14 @@ jobs:
     
     strategy:
       matrix:
-        java: [8, 11] #, 17]
+        java: [11, 17-ea]
+        java-package: [jdk]
+        distribution: [adopt]
+        # When building Java 8 we need JavaFX on JDK basis
+        include: 
+          - java: 8
+            java-package: jdk+fx
+            distribution: zulu
 
     steps:
     - uses: actions/checkout@v2
@@ -25,9 +32,9 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        distribution: 'zulu'
+        distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java }}
-        java-package: jdk+fx
+        java-package: ${{ matrix.java-package }}
 
     - name: Cache local Maven repository
       uses: actions/cache@v2

--- a/.github/workflows/checkBuild.yml
+++ b/.github/workflows/checkBuild.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Determine build profile java 
       id: determine_bp_java
       run: |
-        echo "::set-output name=version::$(echo ${{ matrix.java }} | | sed 's/[^0-9]*//g')"
+        echo "::set-output name=version::$(echo ${{ matrix.java }} | sed 's/[^0-9]*//g')"
       
     - name: Build with Maven
       run: mvn -B clean verify -P java${{ steps.determine_bp_java.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,282 @@
+name: Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  check_code: # Validates the code (see checkBuild.yml)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '8'
+        java-package: jdk+fx
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+      
+    - name: Build with Maven
+      run: mvn -B clean verify -Pjava8
+      
+    - name: Check for uncommited changes
+      run: |
+        if [[ "$(git status --porcelain)" != "" ]]; then
+          echo ----------------------------------------
+          echo git status
+          echo ----------------------------------------
+          git status
+          echo ----------------------------------------
+          echo git diff
+          echo ----------------------------------------
+          git diff
+          echo ----------------------------------------
+          echo Troubleshooting
+          echo ----------------------------------------
+          echo "::error::Unstaged changes detected. Locally try running: git clean -ffdx && mvn -B clean verify"
+          exit 1
+        fi
+
+  prepare_release:
+    runs-on: ubuntu-latest
+    needs: [check_code]
+    outputs:
+      upload_url: ${{ steps.create_draft.outputs.upload_url }}
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Configure Git
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        
+    - name: Un-SNAP 
+      run: mvn -B versions:set -DremoveSnapshot -DgenerateBackupPoms=false
+  
+    - name: Get version
+      id: version
+      # Ignores the suffix
+      run: |
+        read_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        parts=(${read_version//-/ })
+        echo "::set-output name=release::${parts[0]}"
+  
+    - name: Commit and Push
+      run: |
+        git add -A
+        git commit -m "Release ${{ steps.version.outputs.release }}"
+        git push origin
+        git tag v${{ steps.version.outputs.release }}
+        git push origin --tags
+    
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.version.outputs.release }}
+        release_name: v${{ steps.version.outputs.release }}
+        commitish: master
+        body: |
+          ## Installation [![Maven Central](https://img.shields.io/maven-central/v/com.xdev-software/xapi-fx?versionPrefix=${{ steps.version.outputs.release }})](https://mvnrepository.com/artifact/com.xdev-software/xapi-fx)
+          Add the following lines to your pom:
+          ```XML
+          <dependency>
+             <groupId>com.xdev-software</groupId>
+             <artifactId>xapi-fx</artifactId>
+             <version>${{ steps.version.outputs.release }}-java<JavaVersion></version>
+          </dependency>
+          ```
+        draft: false
+        prerelease: false
+
+  publish_central: # Publish the code to central
+    runs-on: ubuntu-latest
+    needs: [prepare_release]
+    strategy:
+      matrix:
+        java: [11] #, 17]
+        java-package: [jdk]
+        distribution: [adopt]
+        include: 
+          # When building Java 8 we need JavaFX on JDK basis
+          - java: 8
+            java-package: jdk+fx
+            distribution: zulu
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Init Git and pull
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        git pull
+    
+    - name: Set up JDK and configure for ossrh
+      uses: actions/setup-java@v2
+      with: # running setup-java again overwrites the settings.xml
+        distribution: ${{ matrix.distribution }}
+        java-version: ${{ matrix.java }}
+        java-package: ${{ matrix.java-package }}
+        server-id: ossrh
+        server-username: MAVEN_CENTRAL_USERNAME
+        server-password: MAVEN_CENTRAL_TOKEN
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+
+    - name: Publish to Apache Maven Central
+      run: mvn -B deploy -Possrh,java${{ matrix.java }}
+      env:
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+  
+  publish-pages:
+    # Java 8-variant has no dependencies
+    name: Publish dependencies and licenses to github pages (Java 11)
+    runs-on: ubuntu-latest
+    needs: [prepare_release]
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Init Git and pull
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        git pull
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
+        java-package: jdk
+
+    - name: Restore - Maven Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-:  
+
+    - name: Build dependencies/licenses files
+      run: mvn -B project-info-reports:dependencies -Pjava8
+
+    - name: Upload licenses - Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: dependencies-licenses
+        path: target/site
+
+    - name: Generate docs/dependencies dir
+      run: mkdir -p docs/dependencies
+
+    - name: Move built files into docs/dependencies
+      run: mv target/site/* docs/dependencies
+
+    - name: Rename dependencies.html to index.html
+      working-directory: docs/dependencies
+      run: mv dependencies.html index.html
+
+    - name: Copy Readme into docs (as index.md)
+      run: cp README.md docs/index.md
+
+    - name: Configure Pages
+      working-directory: docs
+      run: |-
+        echo "theme: jekyll-theme-tactile" > _config.yml
+
+    - name: Deploy to Github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+        enable_jekyll: true
+        
+  build_xdev_ide:
+    runs-on: ubuntu-latest
+    needs: [prepare_release]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Init Git and pull
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        git pull
+      
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '8'
+        java-package: jdk+fx
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+      
+    - name: Build with Maven
+      run: mvn -B clean verify -Pjava8,xdev-ide
+      
+    - uses: actions/upload-artifact@v2
+      with:
+        name: jars-xdev-ide
+        path: target/*.jar
+
+  after_release:
+    runs-on: ubuntu-latest
+    needs: [publish_central, build_xdev_ide]
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Init Git and pull
+      run: |
+        git config --global user.email "actions@github.com"
+        git config --global user.name "GitHub Actions"
+        git pull
+        
+    - name: Inc Version and SNAP root
+      # The versions plugin doesn't work that easily with maven so there are some workarounds
+      run: |
+        echo "Setting version without suffix"
+        read_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        parts=(${read_version//-/ })
+        mvn versions:set -DnewVersion=${parts[0]} -DgenerateBackupPoms=false
+        
+        echo "Incrementing version and set snapshot"
+        mvn versions:set -DnextSnapshot=true -DgenerateBackupPoms=false
+        
+        echo "Set version with suffix"
+        read_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        parts=(${read_version//-/ })
+        mvn versions:set -DnewVersion="${parts[0]}-{version.suffix}-${parts[1]}" -DgenerateBackupPoms=false
+        
+    - name: Git Commit and Push
+      run: |
+        git add -A
+        git commit -m "Preparing for next development iteration"
+        git push origin
+    
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        destination_branch: "develop"
+        pr_title: "Sync back"
+        pr_body: "An automated PR to sync changes back"

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,34 @@
+name: Test Deployment CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_central: # Publish the code to central
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java: [8, 11] #, 17]
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up JDK and configure for ossrh
+      uses: actions/setup-java@v2
+      with: # running setup-java again overwrites the settings.xml
+        distribution: 'zulu'
+        java-version: ${{ matrix.java }}
+        java-package: jdk+fx
+        server-id: ossrh
+        server-username: MAVEN_CENTRAL_USERNAME
+        server-password: MAVEN_CENTRAL_TOKEN
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+
+    - name: Publish to Apache Maven Central
+      run: mvn -B deploy -Possrh,java${{ matrix.java }}
+      env:
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -9,7 +9,14 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 11] #, 17]
+        java: [11, 17-ea]
+        java-package: [jdk]
+        distribution: [adopt]
+        include: 
+          # When building Java 8 we need JavaFX on JDK basis
+          - java: 8
+            java-package: jdk+fx
+            distribution: zulu
 
     steps:
     - uses: actions/checkout@v2
@@ -17,17 +24,24 @@ jobs:
     - name: Set up JDK and configure for ossrh
       uses: actions/setup-java@v2
       with: # running setup-java again overwrites the settings.xml
-        distribution: 'zulu'
+        distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java }}
-        java-package: jdk+fx
+        java-package: ${{ matrix.java-package }}
         server-id: ossrh
         server-username: MAVEN_CENTRAL_USERNAME
         server-password: MAVEN_CENTRAL_TOKEN
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        
+    # Required to map 17-ea to 17
+    # cut away early access and other stuff
+    - name: Determine build profile java 
+      id: determine_bp_java
+      run: |
+        echo "::set-output name=version::$(echo ${{ matrix.java }} | sed 's/[^0-9]*//g')"
 
     - name: Publish to Apache Maven Central
-      run: mvn -B deploy -Possrh,java${{ matrix.java }}
+      run: mvn -B deploy -Possrh,java${{ steps.determine_bp_java.outputs.version }}
       env:
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,4 +1,4 @@
-name: Test Deployment CI
+name: Test Deployment
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [11, 17-ea]
+        java: [11] #, 17-ea]
         java-package: [jdk]
         distribution: [adopt]
         include: 
@@ -32,16 +32,9 @@ jobs:
         server-password: MAVEN_CENTRAL_TOKEN
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-        
-    # Required to map 17-ea to 17
-    # cut away early access and other stuff
-    - name: Determine build profile java 
-      id: determine_bp_java
-      run: |
-        echo "::set-output name=version::$(echo ${{ matrix.java }} | sed 's/[^0-9]*//g')"
 
     - name: Publish to Apache Maven Central
-      run: mvn -B deploy -Possrh,java${{ steps.determine_bp_java.outputs.version }}
+      run: mvn -B deploy -Possrh,java${{ matrix.java }}
       env:
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -263,9 +263,6 @@
 
 		<profile>
 			<id>java8</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
 			<properties>
 				<java.runtime.version>[1.8,9)</java.runtime.version>
 				<version.suffix>java8</version.suffix>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,9 @@
 
 		<profile>
 			<id>java8</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
 			<properties>
 				<java.runtime.version>[1.8,9)</java.runtime.version>
 				<version.suffix>java8</version.suffix>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.xdev-software</groupId>
 	<artifactId>xapi-fx</artifactId>
-	<version>1.0.0_${version.suffix}-SNAPSHOT</version>
+	<version>1.0.0-${version.suffix}-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>XDEV Application Framework JavaFX</name>


### PR DESCRIPTION
Fixes #3

TL;DR
Added dependabot and the following workflows:
* checkBuild
  * Builds LTS variants of the jar for Java 8,11 and 17 (currently commented out)
  * Builds a jar for the XDEV IDE
* test-deployment
  * Allows creation of manual deployments (for SNAPSHOTS)
* release
  * Checks if the build works (for Java 8)
  * Prepares the release by removing ``-SNAPSHOT`` and creating a new version on GitHub
  * Publishes all variants (Java 8 + 11) to maven central/ossrh
  * Builds dependency-information for Java 11 (Java 8 has no dependencies)
  * Builds the jar for the xdev-ide (won't be uploaded to the release and ~30-90 days available - can be rebuilt if required)
  * Prepares for the next development iteration: Increments version + adds SNAPSHOT (it's a bit complicated when there is a variable inside)

ℹ️ The release workflow should be tested at least once, after it got merged

